### PR TITLE
draft-snell-link-method: Add example using fragment identifiers

### DIFF
--- a/httpbis/draft-snell-link-method-11.txt
+++ b/httpbis/draft-snell-link-method-11.txt
@@ -4,12 +4,12 @@
 
 Individual Submission                                           J. Snell
 Internet-Draft
-Intended status: Standards Track                          August 1, 2014
-Expires: February 2, 2015
+Intended status: Standards Track                        October 22, 2014
+Expires: April 25, 2015
 
 
                       HTTP Link and Unlink Methods
-                       draft-snell-link-method-10
+                       draft-snell-link-method-11
 
 Abstract
 
@@ -31,7 +31,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 2, 2015.
+   This Internet-Draft will expire on April 25, 2015.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Snell                   Expires February 2, 2015                [Page 1]
+Snell                    Expires April 25, 2015                 [Page 1]
 
-Internet-Draft        HTTP Link and Unlink Methods           August 2014
+Internet-Draft        HTTP Link and Unlink Methods          October 2014
 
 
 Table of Contents
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Snell                   Expires February 2, 2015                [Page 2]
+Snell                    Expires April 25, 2015                 [Page 2]
 
-Internet-Draft        HTTP Link and Unlink Methods           August 2014
+Internet-Draft        HTTP Link and Unlink Methods          October 2014
 
 
    The target and context IRIs of a Link relationship are determined
@@ -165,9 +165,9 @@ Internet-Draft        HTTP Link and Unlink Methods           August 2014
 
 
 
-Snell                   Expires February 2, 2015                [Page 3]
+Snell                    Expires April 25, 2015                 [Page 3]
 
-Internet-Draft        HTTP Link and Unlink Methods           August 2014
+Internet-Draft        HTTP Link and Unlink Methods          October 2014
 
 
    provide the information about the relationships that are to be
@@ -221,9 +221,9 @@ Internet-Draft        HTTP Link and Unlink Methods           August 2014
 
 
 
-Snell                   Expires February 2, 2015                [Page 4]
+Snell                    Expires April 25, 2015                 [Page 4]
 
-Internet-Draft        HTTP Link and Unlink Methods           August 2014
+Internet-Draft        HTTP Link and Unlink Methods          October 2014
 
 
 6.  Example
@@ -277,9 +277,9 @@ Internet-Draft        HTTP Link and Unlink Methods           August 2014
 
 
 
-Snell                   Expires February 2, 2015                [Page 5]
+Snell                    Expires April 25, 2015                 [Page 5]
 
-Internet-Draft        HTTP Link and Unlink Methods           August 2014
+Internet-Draft        HTTP Link and Unlink Methods          October 2014
 
 
    Example 5: Add an existing resource to a collection:
@@ -304,6 +304,16 @@ Internet-Draft        HTTP Link and Unlink Methods           August 2014
      Link: <acct:joe@example.org>; rel="follow";
        anchor="acct:sally@example.org"
 
+   Example 8: Using the Link anchor attribute to change the context IRI
+   using a fragment identifier (in this example, a link with the
+   relationship type "http://schema.org/knows" is established between
+   "http://example.org/alice#me" and "http://example.com/bob#me"
+
+     LINK /alice HTTP/1.1
+     Host: example.org
+     Link: <http://example.com/bob#me>; rel="http://schema.org/knows";
+       anchor="#me"
+
 7.  Security Considerations
 
    The LINK and UNLINK methods are subject to the same general security
@@ -319,24 +329,21 @@ Internet-Draft        HTTP Link and Unlink Methods           August 2014
    registry at <http://www.iana.org/assignments/http-methods> (see
    Section 8.1 of [RFC7231]).
 
+
+
+
+
+Snell                    Expires April 25, 2015                 [Page 6]
+
+Internet-Draft        HTTP Link and Unlink Methods          October 2014
+
+
             +-------------+------+------------+---------------+
             | Method Name | Safe | Idempotent | Specification |
             +-------------+------+------------+---------------+
             | LINK        | No   | Yes        | Section 3     |
             | UNLINK      | No   | Yes        | Section 4     |
             +-------------+------+------------+---------------+
-
-
-
-
-
-
-
-
-Snell                   Expires February 2, 2015                [Page 6]
-
-Internet-Draft        HTTP Link and Unlink Methods           August 2014
-
 
 9.  References
 
@@ -382,11 +389,4 @@ Author's Address
 
 
 
-
-
-
-
-
-
-
-Snell                   Expires February 2, 2015                [Page 7]
+Snell                    Expires April 25, 2015                 [Page 7]

--- a/httpbis/draft-snell-link-method-11.xml
+++ b/httpbis/draft-snell-link-method-11.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0"?> 
-<!DOCTYPE rfc SYSTEM "rfc2629.dtd" [ 
+<?xml version="1.0"?>
+<!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
   <!ENTITY rfc2119 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml'>
   <!ENTITY rfc2068 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.2068.xml'>
   <!ENTITY rfc5988 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.5988.xml'>
@@ -7,134 +7,134 @@
   <!ENTITY part6 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.7234.xml'>
   <!ENTITY part4 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.7232.xml'>
 ]>
-<?rfc toc="yes"?> 
-<?rfc strict="yes"?> 
-<?rfc symrefs="yes" ?> 
-<?rfc sortrefs="yes"?> 
-<?rfc compact="yes"?> 
-<rfc category="std" ipr="trust200811" docName="draft-snell-link-method-10"> 
-  <front> 
-    <title abbrev="HTTP Link and Unlink Methods"> 
+<?rfc toc="yes"?>
+<?rfc strict="yes"?>
+<?rfc symrefs="yes" ?>
+<?rfc sortrefs="yes"?>
+<?rfc compact="yes"?>
+<rfc category="std" ipr="trust200811" docName="draft-snell-link-method-11">
+  <front>
+    <title abbrev="HTTP Link and Unlink Methods">
       HTTP Link and Unlink Methods
-    </title> 
- 
-    <author initials="J.M." surname="Snell" fullname="James M Snell"> 
-      <address> 
-        <email>jasnell@gmail.com</email> 
-      </address> 
-    </author> 
-    
-    <date month="August" year="2014" /> 
- 
-    <area>Applications</area> 
-    <workgroup>Individual Submission</workgroup> 
-    <keyword>I-D</keyword> 
+    </title>
+
+    <author initials="J.M." surname="Snell" fullname="James M Snell">
+      <address>
+        <email>jasnell@gmail.com</email>
+      </address>
+    </author>
+
+    <date month="October" year="2014" />
+
+    <area>Applications</area>
+    <workgroup>Individual Submission</workgroup>
+    <keyword>I-D</keyword>
     <keyword>http</keyword>
     <keyword>link</keyword>
     <keyword>unlink</keyword>
     <keyword>method</keyword>
- 
-    <abstract> 
+
+    <abstract>
       <t>
         This specification defines the semantics of the LINK and UNLINK
         HTTP methods.
-      </t> 
-    </abstract> 
- 
-  </front> 
-  
-  <middle> 
+      </t>
+    </abstract>
 
-  <section anchor="intro" title="Introduction"> 
+  </front>
+
+  <middle>
+
+  <section anchor="intro" title="Introduction">
 
     <t>
       This specification updates the HTTP LINK and UNLINK methods originally
       defined in <xref target="RFC2068"/>.
     </t>
-  
-    <t>
-      In this document, the key words "MUST", "MUST NOT", "REQUIRED", "SHALL", 
-      "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" 
-      are to be  interpreted as described in <xref target="RFC2119" />.
-    </t> 
 
-  </section> 
-  
-  <section title="Link Relationships" anchor="model">
-    
     <t>
-      The LINK and UNLINK methods are used to manage relationships 
+      In this document, the key words "MUST", "MUST NOT", "REQUIRED", "SHALL",
+      "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL"
+      are to be  interpreted as described in <xref target="RFC2119" />.
+    </t>
+
+  </section>
+
+  <section title="Link Relationships" anchor="model">
+
+    <t>
+      The LINK and UNLINK methods are used to manage relationships
       between resources. Those relationships are defined using the Link
-      model established in Section 3 of <xref target="RFC5988" />. For 
-      every individual link, the context IRI, link relation type, target 
-      IRI, and optional collection of target attributes MUST be considered; 
-      that is, for any effective request URI, there can exist at most one Link 
-      relationship between any context and target IRI pairing with any given 
+      model established in Section 3 of <xref target="RFC5988" />. For
+      every individual link, the context IRI, link relation type, target
+      IRI, and optional collection of target attributes MUST be considered;
+      that is, for any effective request URI, there can exist at most one Link
+      relationship between any context and target IRI pairing with any given
       combination of link relation type and target attributes.
     </t>
-    
+
     <t>
-      Within LINK and UNLINK requests, a <xref target="RFC5988"/> Link 
-      header field is used to describe a Link relationship to be 
+      Within LINK and UNLINK requests, a <xref target="RFC5988"/> Link
+      header field is used to describe a Link relationship to be
       managed. Any single LINK or UNLINK request MAY contain multiple Link
       header fields, each of which describes a separate relationship between
-      a context IRI and target IRI. When a LINK request contains multiple 
+      a context IRI and target IRI. When a LINK request contains multiple
       Link header fields, the server MUST create all of the specified relationships
       or not create any of them. Likewise, when an UNLINK request contains
-      multiple Link header fields, the server MUST either remove all the 
+      multiple Link header fields, the server MUST either remove all the
       specified relationship or not remove any of them.
     </t>
-    
+
     <t>
-      The target and context IRIs of a Link relationship are determined 
-      following the requirements specified in Sections 5.1 and 5.2 of 
+      The target and context IRIs of a Link relationship are determined
+      following the requirements specified in Sections 5.1 and 5.2 of
       <xref target="RFC5988"/>.
     </t>
-    
+
     <t>
       When determining whether or not a relationship already exists between
-      a context IRI and target IRI, implementations will need to compare the 
+      a context IRI and target IRI, implementations will need to compare the
       given IRIs with other, previously established relationships. To do so,
-      the implementation MUST first resolve the IRIs as required by 
-      <xref target="RFC5988" /> and then compare on a case-sensitive, 
-      character-by-character basis. For instance, the IRIs 
-      "http://example.org/foo" and "http://example.org/Foo" MUST NOT be 
+      the implementation MUST first resolve the IRIs as required by
+      <xref target="RFC5988" /> and then compare on a case-sensitive,
+      character-by-character basis. For instance, the IRIs
+      "http://example.org/foo" and "http://example.org/Foo" MUST NOT be
       considered to be equivalent.
     </t>
-    
+
   </section>
-  
+
   <section title="LINK" anchor="link">
-  
+
     <t>
       The LINK method is used to establish one or more relationships between
-      the resource identified by the effective request URI and one or more other 
+      the resource identified by the effective request URI and one or more other
       resources. Metadata contained within Link header fields <xref target="RFC5988"/>
-      provide information about the relationships being established. A payload 
+      provide information about the relationships being established. A payload
       within a LINK request has no defined semantics.
     </t>
-    
+
     <t>
-      LINK requests are idempotent but are not safe. Establishing a 
-      relationship causes an inherent change to the state of the target 
+      LINK requests are idempotent but are not safe. Establishing a
+      relationship causes an inherent change to the state of the target
       resource.
     </t>
-    
+
     <t>
       Any successful response (using a 2xx status code) to a LINK request
       indicates that all of the Link relationships described in the request
-      have been established. No specific 2xx status code is required. 
+      have been established. No specific 2xx status code is required.
     </t>
 
     <t>
       Responses to LINK requests SHOULD contain one Link header field
       for each Link relationship established by the LINK request.
     </t>
-    
+
     <t>
-      Responses to LINK requests are not cacheable. If a LINK request passes 
-      through a cache that has one or more stored responses for the effective 
-      request URI, those stored responses will be invalidated (see Section 6 
+      Responses to LINK requests are not cacheable. If a LINK request passes
+      through a cache that has one or more stored responses for the effective
+      request URI, those stored responses will be invalidated (see Section 6
       of <xref target="RFC7234"/>).
     </t>
 
@@ -142,41 +142,41 @@
       The semantics of the LINK method change to a "conditional LINK" if
       the request message includes an If-Modified-Since, If-Unmodified-
       Since, If-Match, If-None-Match, or If-Range header field
-      (<xref target="RFC7232"/>).  A conditional 
-      LINK requests that the relationship be established only under the 
+      (<xref target="RFC7232"/>).  A conditional
+      LINK requests that the relationship be established only under the
       circumstances described by the conditional header field(s).
     </t>
-    
+
   </section>
-  
+
   <section title="UNLINK" anchor="unlink">
-  
+
     <t>
       The UNLINK method is used to remove one or more relationships
-      between the resource identified by the effective request URI and 
-      other resources. Metadata contained within Link header fields 
-      <xref target="RFC5988"/> provide the information about the 
-      relationships that are to be removed. A payload within an UNLINK request 
+      between the resource identified by the effective request URI and
+      other resources. Metadata contained within Link header fields
+      <xref target="RFC5988"/> provide the information about the
+      relationships that are to be removed. A payload within an UNLINK request
       has no defined semantics.
     </t>
-    
+
     <t>
-      UNLINK request messages are idempotent but are not safe. Removing a 
-      relationship causes an inherent change to the state of the target 
+      UNLINK request messages are idempotent but are not safe. Removing a
+      relationship causes an inherent change to the state of the target
       resource.
     </t>
-    
+
     <t>
       Responses to UNLINK requests SHOULD contain one Link header field
       for each Link relationship removed by the UNLINK request.
     </t>
-    
+
     <t>
       Any successful response (using a 2xx status code) to an UNLINK request
       indicates that all of the Link relationships described in the request
-      have been removed. No specific 2xx status code is required. 
+      have been removed. No specific 2xx status code is required.
     </t>
-    
+
     <t>
       Responses to UNLINK requests are not cacheable. If an UNLINK
       request passes through a cache that has one or more stored responses
@@ -188,42 +188,42 @@
       The semantics of the UNLINK method change to a "conditional UNLINK" if
       the request message includes an If-Modified-Since, If-Unmodified-
       Since, If-Match, If-None-Match, or If-Range header field
-      (<xref target="RFC7232"/>).  A conditional 
-      UNLINK requests that the relationship be established only under the 
+      (<xref target="RFC7232"/>).  A conditional
+      UNLINK requests that the relationship be established only under the
       circumstances described by the conditional header field(s).
     </t>
 
   </section>
 
   <section title="Relationship to other HTTP Methods and Discoverability of Links">
-    
+
     <t>
-      The use of the LINK and UNLINK request methods to manage relationships 
-      between resources has no direct bearing on the use or appearance of Link 
-      header fields within any other HTTP request or response message 
-      involving the same effective request URI. Nor do the methods have any 
+      The use of the LINK and UNLINK request methods to manage relationships
+      between resources has no direct bearing on the use or appearance of Link
+      header fields within any other HTTP request or response message
+      involving the same effective request URI. Nor do the methods have any
       direct normative impact on the use of link-like structures within the resource
       representations returned by a server for any particular resource.
     </t>
-    
+
     <t>
-      Whether and how to represent relationships managed using LINK 
+      Whether and how to represent relationships managed using LINK
       and UNLINK is left solely at the discretion of the server implementation.
     </t>
-    
+
     <t>
-      This specification does not define a means of discovering or 
-      enumerating the relationships that have been established using the 
+      This specification does not define a means of discovering or
+      enumerating the relationships that have been established using the
       LINK request method.
     </t>
-    
+
   </section>
 
   <section title="Example" anchor="example">
-  
+
     <t>There exists a broad range of possible use cases for the LINK and UNLINK
     methods. The examples that follow illustrate a subset of those cases.</t>
-  
+
     <figure><preamble>Example 1: Creating two separate links between an image
     and the profiles of two people associated with the image:</preamble><artwork><![CDATA[
   LINK /images/my_dog.jpg HTTP/1.1
@@ -231,109 +231,120 @@
   Link: <http://example.com/profiles/joe>; rel="tag"
   Link: <http://example.com/profiles/sally>; rel="tag"
     ]]></artwork></figure>
-    
+
     <figure><preamble>Possible response:</preamble><artwork><![CDATA[
   HTTP/1.1 202 Accepted
   Link: <http://example.com/profiles/joe>; rel="tag"
   Link: <http://example.com/profiles/sally>; rel="tag"
     ]]></artwork></figure>
-    
+
     <figure><preamble>Example 2: Removing an existing Link relationship between
     two resources:</preamble><artwork><![CDATA[
   UNLINK /images/my_dog.jpg HTTP/1.1
   Host: example.org
   Link: <http://example.com/profiles/sally>; rel="tag"
     ]]></artwork></figure>
-    
+
     <figure><preamble>Possible response:</preamble><artwork><![CDATA[
   HTTP/1.1 204 No Content
   Link: <http://example.com/profiles/sally>; rel="tag"
     ]]></artwork></figure>
-    
+
     <figure><preamble>Example 3: Establish a "pingback" or "trackback" style link to
     a blog entry about an article</preamble><artwork><![CDATA[
   LINK /articles/an_interesting_article HTTP/1.1
   Host: example.org
   Link: <http://example.com/my_blog_post>; rel="mention"
     ]]></artwork></figure>
-    
+
     <figure><preamble>Example 4: Establish a link between two semantically related
     resources:</preamble><artwork><![CDATA[
   LINK /some-resource HTTP/1.1
   Host: example.org
   Link: <http://example.com/schemas/my_schema>; rel="describedBy"
     ]]></artwork></figure>
-    
+
     <figure><preamble>Example 5: Add an existing resource to a collection:</preamble><artwork><![CDATA[
   LINK /some-collection-resource HTTP/1.1
   Host: example.org
   Link: <http://example.com/my-member-resource>; rel="item"
     ]]></artwork></figure>
-  
-    <figure><preamble>Example 6: Link one resource to another that monitors its 
+
+    <figure><preamble>Example 6: Link one resource to another that monitors its
     current state (e.g. pub/sub)</preamble><artwork><![CDATA[
   LINK /my-resource HTTP/1.1
   Host: example.org
   Link: <http://example.com/my-monitor>; rel="monitor"
     ]]></artwork></figure>
-    
-    <figure><preamble>Example 7: Using the Link anchor attribute to change the 
-     context IRI (in this example, a link relationship is established between 
+
+    <figure><preamble>Example 7: Using the Link anchor attribute to change the
+     context IRI (in this example, a link relationship is established between
      the IRIs "acct:joe@example.org" and "acct:sally@example.org")</preamble>
      <artwork><![CDATA[
   LINK /my-resource HTTP/1.1
   Host: example.org
-  Link: <acct:joe@example.org>; rel="follow"; 
+  Link: <acct:joe@example.org>; rel="follow";
     anchor="acct:sally@example.org"
     ]]></artwork></figure>
-    
+
+    <figure><preamble>Example 8: Using the Link anchor attribute to change the
+     context IRI using a fragment identifier (in this example, a link with the
+     relationship type "http://schema.org/knows" is established between
+     "http://example.org/alice#me" and "http://example.com/bob#me"</preamble>
+     <artwork><![CDATA[
+  LINK /alice HTTP/1.1
+  Host: example.org
+  Link: <http://example.com/bob#me>; rel="http://schema.org/knows";
+    anchor="#me"
+    ]]></artwork></figure>
+
   </section>
 
   <section title="Security Considerations">
     <t>
-      The LINK and UNLINK methods are subject to the same general security 
-      considerations as all HTTP methods as described in 
+      The LINK and UNLINK methods are subject to the same general security
+      considerations as all HTTP methods as described in
       <xref target="RFC7231"/>.
     </t>
-    
+
     <t>
-      Because the LINK and UNLINK methods cause changes to a resource's state, 
-      the server is responsible for determining the client's authorization to 
+      Because the LINK and UNLINK methods cause changes to a resource's state,
+      the server is responsible for determining the client's authorization to
       make such changes.
     </t>
   </section>
 
   <section title="IANA Considerations">
-    
+
     <t>
-      IANA is requested to add the LINK and UNLINK methods to the 
+      IANA is requested to add the LINK and UNLINK methods to the
       permanent registry at &lt;http://www.iana.org/assignments/http-methods&gt;
       (see Section 8.1 of <xref target="RFC7231" />).
     </t>
-    
+
     <texttable>
       <ttcol>Method Name</ttcol>
       <ttcol>Safe</ttcol>
       <ttcol>Idempotent</ttcol>
       <ttcol>Specification</ttcol>
-      
+
       <c>LINK</c>
       <c>No</c>
       <c>Yes</c>
       <c><xref target="link"/></c>
-      
+
       <c>UNLINK</c>
       <c>No</c>
       <c>Yes</c>
       <c><xref target="unlink"/></c>
-      
+
     </texttable>
-    
+
   </section>
-  
+
 </middle>
 <back>
-  <references title="Normative References"> 
+  <references title="Normative References">
     &rfc2119;
     &rfc5988;
     &part2;
@@ -344,5 +355,5 @@
     &rfc2068;
   </references>
 </back>
-</rfc> 
- 
+</rfc>
+


### PR DESCRIPTION
Hi James,

would it be possible to add an example that uses fragment identifiers to draft-snell-link-method? As a [recent discussion in the Hydra W3C Community Group](http://lists.w3.org/Archives/Public/public-hydra/2014Oct/0100.html) showed, people struggle to see that this is possible.

I had an example like like this in mind:

```
 LINK /alice HTTP/1.1
 Host: example.org
 Link: <http://example.com/bob#me>; rel="http://schema.org/knows"; anchor="#me"
```

Which effectively creates this triple

```
 <http://example.org/alice#me> <http://schema.org/knows> <http://example.com/bob#me> .
```

Thanks
